### PR TITLE
[resolves #10] Support for contextual xhrPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ app.createContext({
 });
 ```
 
+### Dynamic XHR Paths
+
+The `fetchrPlugin` method can also be passed a `getXhrPath` function that returns the string for the `xhrPath`. This allows you to dynamically set the `xhrPath` based on the current context. For instance, if you're hosting multiple sites and want to serve XHR via a pattern route like `/:site/api`, you can do the following:
+
+```js
+app.plug(fetchrPlugin({
+    getXhrPath: function (contextOptions) {
+        // `contextOptions` is the object passed to `createContext` above
+        return contextOptions.req.params.site + '/api';
+    }
+}));
+```
+
 ## Fluxible Methods Added
 
 ### actionContext

--- a/lib/fetchr-plugin.js
+++ b/lib/fetchr-plugin.js
@@ -69,6 +69,9 @@ module.exports = function fetchrPlugin(options) {
          */
         plugContext: function plugContext(contextOptions) {
             var xhrContext = contextOptions.xhrContext;
+            if (options.getXhrPath) {
+                xhrPath = options.getXhrPath(contextOptions);
+            }
             return {
                 /**
                  * Adds the service CRUD and getServiceMeta methods to the action context
@@ -98,7 +101,8 @@ module.exports = function fetchrPlugin(options) {
                  */
                 dehydrate: function dehydrate() {
                     return {
-                        xhrContext: contextOptions.xhrContext
+                        xhrContext: contextOptions.xhrContext,
+                        xhrPath: xhrPath
                     };
                 },
                 /**
@@ -108,26 +112,9 @@ module.exports = function fetchrPlugin(options) {
                  */
                 rehydrate: function rehydrate(state) {
                     xhrContext = state.xhrContext;
+                    xhrPath = state.xhrPath;
                 }
             };
-        },
-        /**
-         * Called to dehydrate plugin options
-         * @method dehydrate
-         * @returns {Object}
-         */
-        dehydrate: function dehydrate() {
-            return {
-                xhrPath: xhrPath
-            };
-        },
-        /**
-         * Called to rehydrate plugin options
-         * @method rehydrate
-         * @returns {Object}
-         */
-        rehydrate: function rehydrate(state) {
-            xhrPath = state.xhrPath;
         },
         /**
          * Registers a service to the manager


### PR DESCRIPTION
@redonkulus @ryanashcraft

This provides an option to the plugin `getXhrPath` that will get called for each context that is created. In this way, you can hook into the `contextOptions.req` to generate the xhrPath for that request.