### PR TITLE
rename serviceConstructGetXhrUri to service.constructGetXhrUri

### DIFF
--- a/lib/fetchr-plugin.js
+++ b/lib/fetchr-plugin.js
@@ -89,15 +89,15 @@ module.exports = function fetchrPlugin(options) {
                         create: crudProxy(service, 'create', serviceMeta),
                         read: crudProxy(service, 'read', serviceMeta),
                         update: crudProxy(service, 'update', serviceMeta),
-                        'delete': crudProxy(service, 'delete', serviceMeta)
+                        'delete': crudProxy(service, 'delete', serviceMeta),
+                        constructGetXhrUri: function constructGetXhrUri(resource, params, config) {
+                            config = config || {};
+                            var getUriFn = config.constructGetUri || defaultConstructGetUri;
+                            return getUriFn.call(service, xhrPath, resource, params, config, xhrContext);
+                        }
                     };
                     actionContext.getServiceMeta = function getServiceMeta() {
                         return serviceMeta;
-                    };
-                    actionContext.serviceConstructGetXhrUri = function serviceConstructGetXhrUri(resource, params, config) {
-                        config = config || {};
-                        var getUriFn = config.constructGetUri || defaultConstructGetUri;
-                        return getUriFn.call(service, xhrPath, resource, params, config, xhrContext);
                     };
                 },
                 /**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^2.0.0",
-    "fetchr": "^0.5.0"
+    "fetchr": "^0.5.7"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/tests/unit/lib/fetchr-plugin.js
+++ b/tests/unit/lib/fetchr-plugin.js
@@ -137,12 +137,12 @@ describe('fetchrPlugin', function () {
             });
             contextPlug.plugActionContext(actionContext);
 
-            expect(actionContext.serviceConstructGetXhrUri(
+            expect(actionContext.service.constructGetXhrUri(
                 'resourceFoo',
                 {a: 1}
             )).to.equal('custom2/api/resourceFoo;a=1?device=tablet', 'default construct uri function');
 
-            expect(actionContext.serviceConstructGetXhrUri(
+            expect(actionContext.service.constructGetXhrUri(
                 'resourceFoo',
                 {a: 1},
                 {


### PR DESCRIPTION
Start using service as the namespace.  Should move getServiceMeta in the namespace object at next minor version bump.

@Vijar @redonkulus 